### PR TITLE
[feature] 비밀번호 수정

### DIFF
--- a/src/main/java/com/sparta/seoulmate/controller/UserController.java
+++ b/src/main/java/com/sparta/seoulmate/controller/UserController.java
@@ -160,7 +160,7 @@ public class UserController {
     // 비밀번호 수정
     @PutMapping("/password")
     public ResponseEntity<ApiResponseDto> updatePassword(@RequestBody UpdatePasswordRequestDto requestDto,
-                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+                                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         userService.updatePassword(requestDto, userDetails.getUser());
         return ResponseEntity.ok().body(new ApiResponseDto("비밀번호 수정 성공",HttpStatus.OK.value()));
     }

--- a/src/main/java/com/sparta/seoulmate/dto/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/sparta/seoulmate/dto/UpdatePasswordRequestDto.java
@@ -10,9 +10,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UpdatePasswordRequestDto {
+    private String password;
     private String updatePassword;
 
-    public void updatePassword(String updatePassword) {
-        this.updatePassword = updatePassword;
+    public UpdatePasswordRequestDto updatePassword(String updatePassword) {
+        return UpdatePasswordRequestDto.builder()
+                .password(this.password)
+                .updatePassword(updatePassword)
+                .build();
     }
 }

--- a/src/main/java/com/sparta/seoulmate/entity/PasswordManager.java
+++ b/src/main/java/com/sparta/seoulmate/entity/PasswordManager.java
@@ -21,10 +21,11 @@ public class PasswordManager extends Timestamped {
     private User user;
 
     @Column(nullable = false)
-    private String updatePassword; // 변경된 비밀번호
+    private String password; // 변경된 비밀번호
 
-    public PasswordManager (User user, String updatePassword) {
+
+    public PasswordManager (String password, User user) {
+        this.password = password;
         this.user = user;
-        this.updatePassword = updatePassword;
     }
 }

--- a/src/main/java/com/sparta/seoulmate/entity/User.java
+++ b/src/main/java/com/sparta/seoulmate/entity/User.java
@@ -62,6 +62,9 @@ public class User extends Timestamped {
     @Enumerated(value = EnumType.STRING)
     private UserGenderEnum gender;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private final List<PasswordManager> passwordManagerList = new ArrayList<>();
+
     @Builder.Default
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserInterest> userInterests = new ArrayList<>();
@@ -82,7 +85,7 @@ public class User extends Timestamped {
         this.address = address;
     }
 
-    public void updatePassword(UpdatePasswordRequestDto requestDto) {
-        this.password = requestDto.getUpdatePassword();
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
     }
 }

--- a/src/main/java/com/sparta/seoulmate/repository/PasswordManagerRepository.java
+++ b/src/main/java/com/sparta/seoulmate/repository/PasswordManagerRepository.java
@@ -2,12 +2,20 @@ package com.sparta.seoulmate.repository;
 
 import com.sparta.seoulmate.entity.PasswordManager;
 import com.sparta.seoulmate.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PasswordManagerRepository extends JpaRepository <PasswordManager,Long> {
 
-    List<PasswordManager> findTop4ByUserOrderByCreatedAtDesc(User user);
+    Optional<PasswordManager> findByUser(User user);
+
+    //DESC : 내림차순(높은숫자부터 낮은숫자)
+    //LIMIT 3 : 3건만 조회
+    @Query("SELECT pm.password FROM PasswordManager pm WHERE pm.user = :user ORDER BY pm.id DESC LIMIT 3")
+    List<String> findPasswordTopThree(@Param("user") User user);
 
 }


### PR DESCRIPTION
<!-- Commit Type (제목 작성 시 [] 내의 내용)
- `feature`: 새로운 기능 추가
- `fix`: 버그 수정
- `docs`: 문서 수정
- `refactor`: 코드 리팩토링
- `test`:  테스트 코드 추가
- `init` : 프로젝트 초기 생성
- `style` :코드 포맷팅, 세미콜론 누락, 이후 코드 변경이 없는 경우
- `design` :CSS 등 사용자 UI 디자인 변경
-->


## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

- password_manager
  - 회원가입시 입력한 비밀번호를 password_manager에 담아서 저장하고 비밀번호 변경시 기억하여 최근 3회 비밀번호 사용 제한에 포함했습니다.
- 빌더 패턴으로 변경
  - UpdatePasswordRequestDto에 빌더 패턴을 써주었으나 UserService 내에 public void signUp(SignupRequestDto requestDto)에서 빌더 패턴을 사용하게 했습니다.
- 현재 비밀번호 검증 후 비밀번호 변경 가능으로 수정
  - UpdatePasswordRequestDto에 현재의 비밀번호(password)와 변경할 비밀번호(updatePassword)를 필드로 선언해주고 UserService 내에 public void updatePassword (UpdatePasswordRequestDto requestDto, User user)에 if문을 넣어주었습니다.

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  


## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?
- [ ] 테스트 코드를 작성하셨나요?

## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요, 없을 경우 생략 가능 -->  

```
// 회원가입 시 썼던 비밀번호를 PasswordManager 엔티티에 저장
        ``PasswordManager passwordManager = PasswordManager.builder()
                .user(user)
                .password(password)    // 업데이트된 비밀번호
                .build();
        passwordManagerRepository.save(passwordManager);
```

DB 데이터 삽입으로 테스트
위 코드로 인해 회원가입시 입력했던 비밀번호가 password_manager 테이블에 저장에 되어야 하는데 값이 들어오지 않았습니다.
코드에 문제가 있는 것은 아닌 것 같고... DB에 데이터를 넣어주는 것만으로는 테스트가 이루어질 것 같지 않았습니다.

#### 해결
UserService의 public void signUp(SignupRequestDto requestDto)에서 email, sms 인증 관련을 주석처리하고 포스트맨으로 회원가입을 진행해서 회원가입시 입력했던 비밀번호가 password_manager 테이블에 저장되는 것을 확인했습니다.

또한 최근 3번 사용한 비밀번호 조회를 위해 이전에 작성했던 findTop4ByUserOrderByCreatedAtDesc 관련 로직을 UserService와 PasswordManagerRepository에서 수정해줬습니다. (참고:https://github.com/lazygyu97/SNS)



* 이슈 번호 : Reseolves: #25