### PR TITLE
[feature] 회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/sparta/seoulmate/controller/UserController.java
+++ b/src/main/java/com/sparta/seoulmate/controller/UserController.java
@@ -152,7 +152,7 @@ public class UserController {
     @PutMapping("/image")
     public ResponseEntity<ApiResponseDto> updateImage(
             @RequestPart(value = "file") MultipartFile file,
-            @AuthenticationPrincipal UserDetailsImpl userDetails){
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         if (userDetails == null || userDetails.getUser() == null) {
             // 사용자가 로그인하지 않은 경우 또는 인증 정보가 올바르게 전달되지 않은 경우 처리
@@ -183,6 +183,12 @@ public class UserController {
     public ResponseEntity<ApiResponseDto> updatePassword(@RequestBody UpdatePasswordRequestDto requestDto,
                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
         userService.updatePassword(requestDto, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto("비밀번호 수정 성공",HttpStatus.OK.value()));
+        return ResponseEntity.ok().body(new ApiResponseDto("비밀번호 수정 성공", HttpStatus.OK.value()));
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<String> withdrawUser( @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return userService.withdrawUser(userDetails.getUser());
     }
 }

--- a/src/main/java/com/sparta/seoulmate/entity/User.java
+++ b/src/main/java/com/sparta/seoulmate/entity/User.java
@@ -50,7 +50,6 @@ public class User extends Timestamped {
     @Column(nullable = false)
     private String address;
 
-
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
@@ -58,6 +57,9 @@ public class User extends Timestamped {
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserGenderEnum gender;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Withdrawal> withdrawals = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private final List<PasswordManager> passwordManagerList = new ArrayList<>();
@@ -90,5 +92,9 @@ public class User extends Timestamped {
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
+    }
+
+    public void denyUser() {
+        this.role = UserRoleEnum.DENY;
     }
 }

--- a/src/main/java/com/sparta/seoulmate/entity/UserRoleEnum.java
+++ b/src/main/java/com/sparta/seoulmate/entity/UserRoleEnum.java
@@ -2,7 +2,8 @@ package com.sparta.seoulmate.entity;
 
 public enum UserRoleEnum {
     USER(Authority.USER),  // 사용자 권한
-    ADMIN(Authority.ADMIN);  // 관리자 권한
+    ADMIN(Authority.ADMIN),  // 관리자 권한
+    DENY(Authority.DENY);  // 탈퇴 진행 중인 유저
 
     private final String authority;
 
@@ -17,5 +18,7 @@ public enum UserRoleEnum {
     public static class Authority {
         public static final String USER = "ROLE_USER";
         public static final String ADMIN = "ROLE_ADMIN";
+        public static final String DENY = "ROLE_DENY";
+
     }
 }

--- a/src/main/java/com/sparta/seoulmate/entity/Withdrawal.java
+++ b/src/main/java/com/sparta/seoulmate/entity/Withdrawal.java
@@ -1,0 +1,28 @@
+package com.sparta.seoulmate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "withdrawals")
+public class Withdrawal {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime requestTime; // 신청 시간
+    private LocalDateTime expireTime; // 만료 시간
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/sparta/seoulmate/openApi/scheduler/WithdrawalScheduler.java
+++ b/src/main/java/com/sparta/seoulmate/openApi/scheduler/WithdrawalScheduler.java
@@ -24,7 +24,7 @@ public class WithdrawalScheduler {
     private final UserRepository userRepository;
 
     // 스케줄링 주기 설정
-    @Scheduled(cron = "0 0 1,10,19 * * *") // 60000 : 1분
+    @Scheduled(cron = "0 30 7,15,23 * * *")
     @Transactional
     public void cleanupExpiredWithdrawals() {
         LocalDateTime standardTime = LocalDateTime.now().minusDays(7); // 현재 시간보다 n시간 전에 있었던 것을 삭제 -> n시간이 유예기간

--- a/src/main/java/com/sparta/seoulmate/openApi/scheduler/WithdrawalScheduler.java
+++ b/src/main/java/com/sparta/seoulmate/openApi/scheduler/WithdrawalScheduler.java
@@ -1,0 +1,46 @@
+package com.sparta.seoulmate.openApi.scheduler;
+
+import com.sparta.seoulmate.entity.User;
+import com.sparta.seoulmate.entity.Withdrawal;
+import com.sparta.seoulmate.repository.UserRepository;
+import com.sparta.seoulmate.repository.WithdrawalRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@EnableScheduling
+@AllArgsConstructor
+@Slf4j
+public class WithdrawalScheduler {
+
+    private final WithdrawalRepository withdrawalRepository;
+    private final UserRepository userRepository;
+
+    // 스케줄링 주기 설정
+    @Scheduled(cron = "0 0 1,10,19 * * *") // 60000 : 1분
+    @Transactional
+    public void cleanupExpiredWithdrawals() {
+        LocalDateTime standardTime = LocalDateTime.now().minusDays(7); // 현재 시간보다 n시간 전에 있었던 것을 삭제 -> n시간이 유예기간
+        LocalDateTime currentDateTime = LocalDateTime.now();
+
+        List<Withdrawal> expiryWithdrawals = withdrawalRepository.findByRequestTimeBefore(standardTime);
+
+        // 만료된 회원 탈퇴 신청 정보 삭제
+        withdrawalRepository.deleteAll(expiryWithdrawals);
+
+        // withdrawals에 있는 정보가 삭제 되면서 users에 있는 관련된 정보도 삭제
+        List<User> users = expiryWithdrawals.stream().map(Withdrawal::getUser).toList();
+        userRepository.deleteAll(users);
+
+        log.info("현재 시간: {}", currentDateTime);
+        log.info("탈퇴 요청: {}", standardTime);
+        log.info("현재 시간 - 탈퇴 요청 = 탈퇴 유예 기간");
+    }
+}

--- a/src/main/java/com/sparta/seoulmate/repository/UserRepository.java
+++ b/src/main/java/com/sparta/seoulmate/repository/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User,Long> {
 
     Optional<User> findByUsername(String username);
+
     Optional<User> findByEmail(String email);
 
     Optional<User> findByPhone(String phone);

--- a/src/main/java/com/sparta/seoulmate/repository/WithdrawalRepository.java
+++ b/src/main/java/com/sparta/seoulmate/repository/WithdrawalRepository.java
@@ -1,0 +1,20 @@
+package com.sparta.seoulmate.repository;
+
+import com.sparta.seoulmate.entity.Withdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WithdrawalRepository extends JpaRepository<Withdrawal, Long> {
+    // 만료 시간과 상태로 회원 탈퇴 신청 정보를 검색하는 메서드
+    List<Withdrawal> findByRequestTimeBefore(LocalDateTime standardTime);
+
+    Optional<Withdrawal> findByUserId(Long id);
+
+    List<Withdrawal> findByExpireTimeBefore(LocalDateTime expireTime);
+
+}


### PR DESCRIPTION
<!-- Commit Type (제목 작성 시 [] 내의 내용)
- `feature`: 새로운 기능 추가
- `fix`: 버그 수정
- `docs`: 문서 수정
- `refactor`: 코드 리팩토링
- `test`:  테스트 코드 추가
- `init` : 프로젝트 초기 생성
- `style` :코드 포맷팅, 세미콜론 누락, 이후 코드 변경이 없는 경우
- `design` :CSS 등 사용자 UI 디자인 변경
-->


## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->
회원 탈퇴 신청 시 바로 회원 탈퇴(해당 user의 정보 삭제)가 되는 것이 아닌 회원 탈퇴 신청을 한 user를 withdrawalRepository에 담아주고 withdrawals table에서 확인할 수 있게 만들었습니다.

회원 탈퇴의 유예 기간은 7일이며 public void cleanupExpiredWithdrawals()의 LocalDateTime standardTime = LocalDateTime.now().minusDays(7); 에서 설정해주었습니다.
withdrawals table의 expire_time에서 삭제가 완료될 날짜와 시간을 보여주는데 이 부분은 UserService의 public ResponseEntity<String> withdrawUser(User user)에서 LocalDateTime expireTime = LocalDateTime.now().plusDays(7); 부분입니다.

`LocalDateTime standardTime = LocalDateTime.now().minusDays(7);` 와 `LocalDateTime expireTime = LocalDateTime.now().plusDays(7);`의 날짜, 시간을 갖게 해주어야 withdrawals table의 expire_time에서 알맞은 회원 탈퇴 시간 확인이 가능합니다.

회원이 탈퇴 신청을 하고 갖는 유예 기간은 7일로 설정했습니다.
그 7일 안에 회원이 DENY 역할을 갖고 어떤 행동을 할 수 있는지에 대한 설정과 회원 탈퇴 신청을 취소하는 기능은 JwtAuthenticationFilter와 관련 있어서 팀장님이 확인해주신다고 하셨습니다.

public class WithdrawalScheduler에서 @Scheduled(cron = "0 30 7,15,23 * * *")를 이용하여 스케줄러가 매일 7시 30분/15시 30분/23시 30분에 작동하게 설정하고 회원 탈퇴 유예 기간이 만료된 정보들을 검사하고 탈퇴 처리를 합니다.

ex) 10일 13시에 탈퇴한 회원 A -> 17일 15시 30분에 작동하는 스케줄러가 회원 탈퇴 처리
ex) 11일 15시 32분에 탈퇴한 회원 B -> 18일 23시 30분에 작동하는 스케줄러가 회원 탈퇴 처리
ex) 11일 23시 57분에 탈퇴한 회원 C -> 19일 7시 30분에 작동하는 스케줄러가 회원 탈퇴 처리

### 완성된 기능 확인
탈퇴 유예 기간은 7일이며, 2023-09-07 19:33에 탈퇴 신청을 한 user_id 17번의 user의 정보가 withdrawals table에서 확인됩니다.
![image](https://github.com/lazygyu97/seoulmate/assets/132984807/e2447bef-76cb-44ae-a146-10daccec5cb4)
expire_time에 보이는 것과 같이 2023-09-14 19:33에 탈퇴 완료 예정이며 23시 30분에 작동하는 스케줄러로 인해 회원 탈퇴(회원 정보 삭제)가 이루어집니다. 예정된 탈퇴 시간과 차이가 있으며 약 5~6시간이 더 걸릴 것으로 예상됩니다.
만료 기간이 다 된 정보를 스케줄러가 감지하여 withdrawals table에서 해당 데이터를 삭제하고 삭제된 데이터의 같은 user_id를 갖고 있는 회원 정보(컬럼)를 users table에서 삭제해서 회원 탈퇴가 이루어지게 됩니다.


## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?
- [ ] 테스트 코드를 작성하셨나요?

## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요, 없을 경우 생략 가능 -->  

- 처음에 Redis를 사용하여 다양하고 많은 오류가 있고 헤맸습니다...
  - Redis를 사용할 때의 오류
    1. 오류…
    
    ```java
    java.lang.IllegalArgumentException: DefaultSerializer requires a Serializable payload but received an object of type [com.sparta.seoulmate.entity.redishash.Withdrawal]
    ```
    
       - **`com.sparta.seoulmate.entity.redishash.Withdrawal`** 클래스가 직렬화 가능한(Serializable) 형태로 구현되어 있지 않아서 발생
       - Redis는 데이터를 저장할 때 기본적으로 직렬화된 형태로 저장
       - **`Withdrawal`** 클래스는 이러한 직렬화를 지원하지 않고 있다!
       - 해결하기…
           - 클래스 내부에서 사용하는 모든 멤버 변수 또한 직렬화 가능해야 하기 때문에 해당 변수도 **`Serializable`** 인터페이스를 구현
        
                ```java
                import java.io.Serializable;
                ```

                ```java
                public class Withdrawal implements Serializable
                ```
    2. 타임투리브(만료시간만!) 이벤트 발생을 위해 → 퍼블리시, 섭스크립 매커니즘 사용해야함..
     - 오류
        
        ```java
        Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
        2023-09-05T20:15:56.183+09:00 ERROR 18676 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 
        
        ***************************
        APPLICATION FAILED TO START
        ***************************
        
        Description:
        
        Parameter 11 of constructor in com.sparta.seoulmate.service.UserService required a bean of type 'org.springframework.data.redis.core.RedisTemplate' that could not be found.
        
        Action:
        
        Consider defining a bean of type 'org.springframework.data.redis.core.RedisTemplate' in your configuration.
        
        Process finished with exit code 1
        ```
        
    - 해결
        - UserService
            
            ```java
            private final RedisTemplate<String, String> redisTemplate;
            ```
            
        - RedisMessagePublisher
            
            ```java
            private final RedisTemplate<String, String> redisTemplate;
            ```
            
        - RedisMessageSubscriber
            
                ```java
                private final UserService userService;
                ```
            
        - RedisPubSubApplication
            
                ```java
                private final RedisMessagePublisher redisMessagePublisher;
                ```

- Redis 사용으로 기능을 완성시켜 보려고 했으나 Reids에 담아야 하는 정보는 일회성이 강한 정보만 담는 것이 맞고 탈퇴한 회원의 정보같이 중요한 데이터는 담기에 부적절하다는 피드백을 받아서 public class WithdrawalScheduler을 생성하고 스케줄러를 사용하였습니다.

- withdrawals table의 저장되는 컬럼의 user_id에 null값이 찍힘
    
    ```java
    Withdrawal withdrawal = Withdrawal.builder()
                    .id(targetUser.getId())
                    .requestTime(now)
                    .scheduledDeletionTime(scheduledDeletionTime)
                    .status(WithdrawalStatusEnum.PENDING) // 탈퇴 상태를 대기 중으로 설정
                    .build();
    ```
    
    - .id(targetUser.getId())를 .user(targetUser) // 사용자 엔티티를 설정으로 수정
        
        ```java
        LocalDateTime now = LocalDateTime.now();
                LocalDateTime scheduledDeletionTime = now.plusMinutes(1);
                Withdrawal withdrawal = Withdrawal.builder()
                        .user(targetUser) // 사용자 엔티티를 설정
                        .requestTime(now)
                        .scheduledDeletionTime(scheduledDeletionTime)
                        .status(WithdrawalStatusEnum.PENDING)
                        .build();
        ```
## Issue Tracker

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. 두 개 이상 작성 가능-->



## 이슈 번호 Reseolves: #39